### PR TITLE
Check if context is undefined before issuing warning

### DIFF
--- a/lib/useLocomotiveScroll.hook.tsx
+++ b/lib/useLocomotiveScroll.hook.tsx
@@ -4,13 +4,11 @@ import { LocomotiveScrollContext, LocomotiveScrollContextValue } from './Locomot
 export function useLocomotiveScroll(): LocomotiveScrollContextValue {
   const context = useContext(LocomotiveScrollContext)
 
-  useEffect(() => {
-    if (!context.scroll) {
-      console.warn(
-        'react-locomotive-scroll: the context is missing. You may be using the hook without registering LocomotiveScrollProvider, or you may be using the hook in a component which is not wrapped by LocomotiveScrollProvider.'
-      )
-    }
-  }, [context.scroll])
+  if (context === undefined) {
+    console.warn(
+      'react-locomotive-scroll: the context is missing. You may be using the hook without registering LocomotiveScrollProvider, or you may be using the hook in a component which is not wrapped by LocomotiveScrollProvider.'
+    )
+  }
 
   return context
 }


### PR DESCRIPTION
Prior to this change, a warning was being issued when `context.scroll` was falsy (`undefined`, `null`, etc). Since `scroll` defaults to `null` (see [LocomotiveScroll.context.tsx#L12](https://github.com/toinelin/react-locomotive-scroll/blob/main/lib/LocomotiveScroll.context.tsx#L12)) the warning was occurring even if the context was defined, but the scroll ref wasn’t yet ready.

Resolves #19. Resolves #17.